### PR TITLE
Васильев К.А

### DIFF
--- a/google_checks.xml
+++ b/google_checks.xml
@@ -1,0 +1,255 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html.
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="warning"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <module name="TreeWalker">
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format"
+                      value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message"
+                      value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens"
+                      value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlySame"/>
+            <property name="tokens"
+                      value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAlone"/>
+            <property name="option" value="alone"/>
+            <property name="tokens"
+                      value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+                     value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+            <message key="ws.notPreceded"
+                     value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapDot"/>
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapComma"/>
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/258 -->
+            <property name="id" value="SeparatorWrapEllipsis"/>
+            <property name="tokens" value="ELLIPSIS"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/259 -->
+            <property name="id" value="SeparatorWrapArrayDeclarator"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+                     value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+                     value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LambdaParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+                     value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+            <message key="ws.preceded"
+                     value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+            <message key="ws.illegalFollow"
+                     value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="2"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="2"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="2"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="CustomImportOrder">
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens"
+                      value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>
+            <property name="allowLineBreaks" value="true"/>
+        </module>
+        <module name="ParenPad"/>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens"
+                      value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationMostCases"/>
+            <property name="tokens"
+                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationVariables"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="SummaryJavadoc">
+            <property name="forbiddenSummaryFragments"
+                      value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        </module>
+        <module name="JavadocParagraph"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target"
+                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+                     value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,53 +1,148 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>ru.hh.school</groupId>
-    <artifactId>maven.practice</artifactId>
-    <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <groupId>sample.plugin</groupId>
+    <artifactId>stoplist-maven-plugin</artifactId>
+    <version>1.0.1-RELEASE</version>
+    <packaging>maven-plugin</packaging>
 
-    <name>maven.practice</name>
-    <url>https://school.hh.ru/</url>
+    <name>hello-maven-plugin Maven Plugin</name>
+
+    <prerequisites>
+        <maven>${maven.version}</maven>
+    </prerequisites>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdk.version>8</jdk.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.version>3.3.9</maven.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.8.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.11</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.5.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
-        <pluginManagement>
+        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
             <plugins>
                 <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_maven-plugin_packaging -->
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
-                    <configuration>
-                        <!--<release>${jdk.version}</release>--><!--TODO uncomment this line, if you use Java9+ or delete-->
-                        <source>${jdk.version}</source>
-                        <target>${jdk.version}</target>
-                    </configuration>
+                    <version>3.7.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <version>3.5.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.20.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-invoker-plugin</artifactId>
+                    <version>3.0.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <!-- <goalPrefix>maven-archetype-plugin</goalPrefix> -->
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>help-goal</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -89,14 +89,6 @@
                     <version>3.0.2</version>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.5.1</version>
-                </plugin>
-                <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.20.1</version>
                 </plugin>
@@ -145,6 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <maven.version>3.3.9</maven.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
             <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -142,6 +149,42 @@
                     <source>8</source>
                     <target>8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.0.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.sevntu-checkstyle</groupId>
+                        <artifactId>sevntu-checkstyle-maven-plugin</artifactId>
+                        <version>1.32.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.12</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <sourceDirectories>
+                                <sourceDirectory>${basedir}/src</sourceDirectory>
+                            </sourceDirectories>
+                            <configLocation>google_checks.xml</configLocation>
+                            <encoding>UTF-8</encoding>
+                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                            <violationSeverity>error</violationSeverity>
+                            <consoleOutput>true</consoleOutput>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/sample/plugin/MapInFileCache.java
+++ b/src/main/java/sample/plugin/MapInFileCache.java
@@ -1,117 +1,104 @@
 package sample.plugin;
 
-import org.apache.maven.plugin.logging.Log;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.HashMap;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.io.*;
-import java.util.HashMap;
 
-/**
- * Cache that use last modified date of file and store it in file
- */
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.logging.Log;
+
+/** Cache that use last modified date of file and store it in file. */
 @Named
 @Singleton
 public class MapInFileCache implements StopListCache {
 
-    /**
-     * Map for cache result.
-     * Key is String canonical path to file
-     * Value is lastModified of file
-     */
-    private HashMap<String, Long> lastModifiedCache = new HashMap<>();
+  /** Map for cache result. Key is String canonical path to file Value is lastModified of file */
+  private HashMap<String, Long> lastModifiedCache = new HashMap<>();
 
-    /**
-     * Path to file for cache result
-     */
-    private String FILE_CACHE_PATH = "target/plugins-cache/stop-list/last-modified-files.cache";
+  /** Path to file for cache result. */
+  private static final String FILE_CACHE_PATH =
+      "target/plugins-cache/stop-list/last-modified-files.cache";
 
-    private Log logger;
+  private Log logger;
 
-    @Override
-    public void setLogger(Log logger) {
-        this.logger = logger;
+  @Override
+  public void setLogger(Log logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public boolean addToCache(File file) {
+    try {
+      String canonicalPath = file.getCanonicalPath();
+      long lastModified = file.lastModified();
+      lastModifiedCache.put(canonicalPath, lastModified);
+
+      return true;
+    } catch (IOException e) {
+      logger.info("Unable to add file to cache: " + file.getPath());
+      logger.debug(e);
+      return false;
+    }
+  }
+
+  @Override
+  public boolean isFileChanged(File file) {
+    try {
+      String canonicalPath = file.getCanonicalPath();
+      Long modifiedCache = lastModifiedCache.get(canonicalPath);
+      if (modifiedCache == null) {
+        return true;
+      }
+
+      return modifiedCache == file.lastModified();
+    } catch (IOException e) {
+      logger.info("Unable read file: " + file.getPath());
+      logger.debug(e);
+      return true;
+    }
+  }
+
+  @Override
+  public void beforeStart() {
+    File file = new File(FILE_CACHE_PATH);
+    if (!file.exists()) {
+      return;
     }
 
-    @Override
-    public boolean addToCache(File file) {
-        try {
-            String canonicalPath = file.getCanonicalPath();
-            long lastModified = file.lastModified();
-            lastModifiedCache.put(canonicalPath, lastModified);
+    try (FileInputStream inputStream = new FileInputStream(FILE_CACHE_PATH);
+        ObjectInputStream objectInputStream = new ObjectInputStream(inputStream)) {
+      lastModifiedCache = (HashMap) objectInputStream.readObject();
+    } catch (Exception e) {
+      logger.info("Unable deserialize cache from file: " + FILE_CACHE_PATH);
+      logger.debug(e);
+    }
+  }
 
-            return true;
-        } catch (IOException e) {
-            logger.info("Unable to add file to cache: " + file.getPath());
-            logger.debug(e);
-            return false;
-        }
+  @Override
+  public void beforeClose() {
+    // write cache to file
+    File cacheFile = new File(FILE_CACHE_PATH);
+    try {
+      FileUtils.touch(cacheFile);
+    } catch (IOException e) {
+      logger.info("Unable create cache file: " + FILE_CACHE_PATH);
+      logger.debug(e);
     }
 
-    @Override
-    public boolean isFileChanged(File file) {
-        try {
-            String canonicalPath = file.getCanonicalPath();
-            Long modifiedCache = lastModifiedCache.get(canonicalPath);
-            if (modifiedCache == null) {
-                return true;
-            }
-
-            return modifiedCache == file.lastModified();
-        } catch (IOException e) {
-            logger.info("Unable read file: " + file.getPath());
-            logger.debug(e);
-            return true;
-        }
+    try (FileOutputStream outputStream = new FileOutputStream(cacheFile);
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+      objectOutputStream.flush();
+      objectOutputStream.writeObject(lastModifiedCache);
+    } catch (IOException e) {
+      logger.info("Unable create cache file: " + FILE_CACHE_PATH);
+      logger.debug(e);
     }
-
-    @Override
-    public void beforeStart() {
-        File file = new File(FILE_CACHE_PATH);
-        if (!file.exists()) {
-            return;
-        }
-
-        try {
-            FileInputStream inputStream = new FileInputStream(FILE_CACHE_PATH);
-            ObjectInputStream objectInputStream = new ObjectInputStream(inputStream);
-            lastModifiedCache = (HashMap) objectInputStream.readObject();
-            objectInputStream.close();
-        } catch (Exception e) {
-            logger.info("Unable deserialize cache from file: " + FILE_CACHE_PATH);
-            logger.debug(e);
-        }
-
-    }
-
-    @Override
-    public void beforeClose() {
-        // write cache to file
-
-        File cacheFile = new File(FILE_CACHE_PATH);
-        File parent = cacheFile.getParentFile();
-
-        if (!parent.exists()) {
-            parent.mkdirs();
-        }
-
-        try {
-            cacheFile.createNewFile();
-        } catch (IOException e) {
-            logger.info("Unable create cache file: " + FILE_CACHE_PATH);
-            logger.debug(e);
-        }
-
-        try (
-                FileOutputStream outputStream = new FileOutputStream(cacheFile);
-                ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)
-        ) {
-            objectOutputStream.flush();
-            objectOutputStream.writeObject(lastModifiedCache);
-        } catch (IOException e) {
-            logger.info("Unable create cache file: " + FILE_CACHE_PATH);
-            logger.debug(e);
-        }
-    }
-
+  }
 }

--- a/src/main/java/sample/plugin/MapInFileCache.java
+++ b/src/main/java/sample/plugin/MapInFileCache.java
@@ -1,0 +1,117 @@
+package sample.plugin;
+
+import org.apache.maven.plugin.logging.Log;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.*;
+import java.util.HashMap;
+
+/**
+ * Cache that use last modified date of file and store it in file
+ */
+@Named
+@Singleton
+public class MapInFileCache implements StopListCache {
+
+    /**
+     * Map for cache result.
+     * Key is String canonical path to file
+     * Value is lastModified of file
+     */
+    private HashMap<String, Long> lastModifiedCache = new HashMap<>();
+
+    /**
+     * Path to file for cache result
+     */
+    private String FILE_CACHE_PATH = "target/plugins-cache/stop-list/last-modified-files.cache";
+
+    private Log logger;
+
+    @Override
+    public void setLogger(Log logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public boolean addToCache(File file) {
+        try {
+            String canonicalPath = file.getCanonicalPath();
+            long lastModified = file.lastModified();
+            lastModifiedCache.put(canonicalPath, lastModified);
+
+            return true;
+        } catch (IOException e) {
+            logger.info("Unable to add file to cache: " + file.getPath());
+            logger.debug(e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isFileChanged(File file) {
+        try {
+            String canonicalPath = file.getCanonicalPath();
+            Long modifiedCache = lastModifiedCache.get(canonicalPath);
+            if (modifiedCache == null) {
+                return true;
+            }
+
+            return modifiedCache == file.lastModified();
+        } catch (IOException e) {
+            logger.info("Unable read file: " + file.getPath());
+            logger.debug(e);
+            return true;
+        }
+    }
+
+    @Override
+    public void beforeStart() {
+        File file = new File(FILE_CACHE_PATH);
+        if (!file.exists()) {
+            return;
+        }
+
+        try {
+            FileInputStream inputStream = new FileInputStream(FILE_CACHE_PATH);
+            ObjectInputStream objectInputStream = new ObjectInputStream(inputStream);
+            lastModifiedCache = (HashMap) objectInputStream.readObject();
+            objectInputStream.close();
+        } catch (Exception e) {
+            logger.info("Unable deserialize cache from file: " + FILE_CACHE_PATH);
+            logger.debug(e);
+        }
+
+    }
+
+    @Override
+    public void beforeClose() {
+        // write cache to file
+
+        File cacheFile = new File(FILE_CACHE_PATH);
+        File parent = cacheFile.getParentFile();
+
+        if (!parent.exists()) {
+            parent.mkdirs();
+        }
+
+        try {
+            cacheFile.createNewFile();
+        } catch (IOException e) {
+            logger.info("Unable create cache file: " + FILE_CACHE_PATH);
+            logger.debug(e);
+        }
+
+        try (
+                FileOutputStream outputStream = new FileOutputStream(cacheFile);
+                ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)
+        ) {
+            objectOutputStream.flush();
+            objectOutputStream.writeObject(lastModifiedCache);
+        } catch (IOException e) {
+            logger.info("Unable create cache file: " + FILE_CACHE_PATH);
+            logger.debug(e);
+        }
+    }
+
+}

--- a/src/main/java/sample/plugin/StopListCache.java
+++ b/src/main/java/sample/plugin/StopListCache.java
@@ -1,0 +1,46 @@
+package sample.plugin;
+
+import org.apache.maven.plugin.logging.Log;
+
+import java.io.File;
+
+/**
+ * Interface for plugin caching
+ */
+public interface StopListCache {
+
+    /**
+     * Adds file to cache
+     *
+     * @param file to add
+     * @return is file was success added to cache
+     */
+    boolean addToCache(File file);
+
+    /**
+     * Sets apache plugin logger
+     *
+     * @param logger to set
+     */
+    void setLogger(Log logger);
+
+    /**
+     * Determinate is file was changed
+     *
+     * @param file to check
+     * @return boolean result
+     */
+    boolean isFileChanged(File file);
+
+    /**
+     * Runs before plugin start to work
+     */
+    default void beforeClose() {
+    }
+
+    /**
+     * Runs before plugin finish to work
+     */
+    default void beforeStart() {
+    }
+}

--- a/src/main/java/sample/plugin/StopListCache.java
+++ b/src/main/java/sample/plugin/StopListCache.java
@@ -1,46 +1,38 @@
 package sample.plugin;
 
-import org.apache.maven.plugin.logging.Log;
-
 import java.io.File;
 
-/**
- * Interface for plugin caching
- */
+import org.apache.maven.plugin.logging.Log;
+
+/** Interface for plugin caching. */
 public interface StopListCache {
 
-    /**
-     * Adds file to cache
-     *
-     * @param file to add
-     * @return is file was success added to cache
-     */
-    boolean addToCache(File file);
+  /**
+   * Adds file to cache.
+   *
+   * @param file to add
+   * @return is file was success added to cache
+   */
+  boolean addToCache(File file);
 
-    /**
-     * Sets apache plugin logger
-     *
-     * @param logger to set
-     */
-    void setLogger(Log logger);
+  /**
+   * Sets apache plugin logger.
+   *
+   * @param logger to set
+   */
+  void setLogger(Log logger);
 
-    /**
-     * Determinate is file was changed
-     *
-     * @param file to check
-     * @return boolean result
-     */
-    boolean isFileChanged(File file);
+  /**
+   * Determinate is file was changed.
+   *
+   * @param file to check
+   * @return boolean result
+   */
+  boolean isFileChanged(File file);
 
-    /**
-     * Runs before plugin start to work
-     */
-    default void beforeClose() {
-    }
+  /** Runs before plugin start to work. */
+  default void beforeClose() {}
 
-    /**
-     * Runs before plugin finish to work
-     */
-    default void beforeStart() {
-    }
+  /** Runs before plugin finish to work. */
+  default void beforeStart() {}
 }

--- a/src/main/java/sample/plugin/StopListMojo.java
+++ b/src/main/java/sample/plugin/StopListMojo.java
@@ -1,5 +1,13 @@
 package sample.plugin;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 
@@ -7,252 +15,224 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import javax.inject.Inject;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
-
-/**
- * Plugin for search and react on stop-words in project
- */
+/** Plugin for search and react on stop-words in project. */
 @Mojo(name = "check", defaultPhase = LifecyclePhase.COMPILE)
 public class StopListMojo extends AbstractMojo {
 
-    /**
-     * List of files/folders where search will be excluded
-     */
-    @Parameter(property = "excludes")
-    private List<String> excludes = new ArrayList<>();
+  /** List of files/folders where search will be excluded. */
+  @Parameter(property = "excludes")
+  private List<String> excludes = new ArrayList<>();
 
-    /**
-     * List of cached canonical paths of excludes param
-     */
-    private List<String> excludeCanonical = new ArrayList<>();
+  /** List of cached canonical paths of excludes param. */
+  private List<String> excludeCanonical = new ArrayList<>();
 
-    /**
-     * List of stop-words to search for
-     */
-    @Parameter(property = "stopWords", required = true)
-    private List<String> stopWords = new ArrayList<>();
+  /** List of stop-words to search for. */
+  @Parameter(property = "stopWords", required = true)
+  private List<String> stopWords = new ArrayList<>();
 
-    /**
-     * Error level of plugin.
-     * Acceptable values is "WARN" and "ERROR"
-     * <p>
-     * On "WARN" plugin is just log if stop-words was found
-     * On "ERROR" plugin is breaking the build
-     */
-    @Parameter(defaultValue = "WARN", property = "errorLevel")
-    String errorLevel;
+  /**
+   * Error level of plugin. Acceptable values is "WARN" and "ERROR".
+   *
+   * <p>On "WARN" plugin is just log if stop-words was found On "ERROR" plugin is breaking the build
+   */
+  @Parameter(defaultValue = "WARN", property = "errorLevel")
+  String errorLevel;
 
-    /**
-     * Should or not case of stop words will be ignored
-     */
-    @Parameter(defaultValue = "false")
-    private boolean ignoreCase;
+  /** Should or not case of stop words will be ignored. */
+  @Parameter(defaultValue = "false")
+  private boolean ignoreCase;
 
-    /**
-     * If errors was found build will be breaking
-     */
-    private boolean hasErrors = false;
+  /** If errors was found build will be breaking. */
+  private boolean hasErrors = false;
 
-    @Inject
-    private StopListCache cache;
+  @Inject private StopListCache cache;
 
-    @Override
-    public void execute() throws MojoExecutionException {
-        init();
-        checkInDirectory(new File("."));
+  @Override
+  public void execute() throws MojoExecutionException {
+    init();
+    checkInDirectory(new File("."));
 
-        beforeClose();
-        if (hasErrors) {
-            throw new MojoExecutionException("Stop-words found in source!");
-        }
+    beforeClose();
+    if (hasErrors) {
+      throw new MojoExecutionException("Stop-words found in source!");
+    }
+  }
+
+  /** Runs in start of plugin work. */
+  private void init() {
+    initCanonicalPaths();
+    cache.setLogger(getLog());
+    cache.beforeStart();
+  }
+
+  /** Runs before plugin finish work. */
+  private void beforeClose() {
+    cache.beforeClose();
+  }
+
+  /** Fill exclude canonical paths. */
+  private void initCanonicalPaths() {
+    for (String excludePath : excludes) {
+      File file = new File(excludePath);
+      if (!file.exists()) {
+        continue;
+      }
+
+      try {
+        excludeCanonical.add(file.getCanonicalPath());
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  /**
+   * Recursive search in directory and files.
+   *
+   * @param directory where search to start
+   */
+  private void checkInDirectory(File directory) {
+    if (!directory.canRead()) {
+      handleNoAccess(directory);
+      return;
     }
 
-    /**
-     * Runs in start of plugin work
-     */
-    private void init() {
-        initCanonicalPaths();
-        cache.setLogger(getLog());
-        cache.beforeStart();
+    File[] files = directory.listFiles();
+    if (files == null) {
+      return;
     }
 
-    /**
-     * Runs before plugin finish work
-     */
-    private void beforeClose() {
-        cache.beforeClose();
+    for (File file : files) {
+      if (isFileExcluded(file)) {
+        continue;
+      }
+
+      checkFile(file);
+      if (file.isDirectory()) {
+        checkInDirectory(file);
+      }
+    }
+  }
+
+  /**
+   * Checks file for stop-words.
+   *
+   * @param file to check
+   */
+  private void checkFile(File file) {
+    if (!file.canRead()) {
+      handleNoAccess(file);
+      return;
     }
 
-    /**
-     * Fill exclude canonical paths
-     */
-    private void initCanonicalPaths() {
-        for (String excludePath : excludes) {
-            File file = new File(excludePath);
-            if (!file.exists()) {
-                continue;
-            }
+    checkFileName(file);
+    if (!file.isDirectory()) {
+      checkFileContent(file);
+    }
+  }
 
-            try {
-                excludeCanonical.add(file.getCanonicalPath());
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
+  /**
+   * Check file name for stop-words.
+   *
+   * @param file to check
+   */
+  private void checkFileName(File file) {
+    String fileName = file.getName();
+    if (ignoreCase) {
+      fileName = fileName.toLowerCase();
     }
 
-    /**
-     * Recursive search in directory and files
-     *
-     * @param directory where search to start
-     */
-    private void checkInDirectory(File directory) {
-        if (!directory.canRead()) {
-            handleNoAccess(directory);
-            return;
-        }
+    for (String stopWord : stopWords) {
+      if (ignoreCase) {
+        stopWord = stopWord.toLowerCase();
+      }
+      if (fileName.contains(stopWord)) {
+        String entityType = file.isDirectory() ? "Directory" : "File";
+        handleStopWordDetected(
+            String.format(
+                "%s name contains stop-word '%s', path: %s", entityType, stopWord, file.getPath()));
+      }
+    }
+  }
 
-        File[] files = directory.listFiles();
-        if (files == null) {
-            return;
-        }
-
-        for (File file : files) {
-            if (isFileExcluded(file)) {
-                continue;
-            }
-
-            checkFile(file);
-            if (file.isDirectory()) {
-                checkInDirectory(file);
-            }
-        }
+  /**
+   * Check file content for stop-words.
+   *
+   * @param file to check
+   */
+  private void checkFileContent(File file) {
+    if (!cache.isFileChanged(file)) {
+      getLog().debug("file wasn't change " + file.getAbsolutePath());
+      return;
     }
 
-    /**
-     * Checks file for stop-words
-     *
-     * @param file to check
-     */
-    private void checkFile(File file) {
-        if (!file.canRead()) {
-            handleNoAccess(file);
-            return;
-        }
+    try {
+      Scanner scanner = new Scanner(file);
 
-        checkFileName(file);
-        if (!file.isDirectory()) {
-            checkFileContent(file);
-        }
-    }
+      int lineNum = 0;
+      while (scanner.hasNextLine()) {
+        String line = scanner.nextLine();
+        lineNum++;
 
-    /**
-     * Check file name for stop-words
-     *
-     * @param file to check
-     */
-    private void checkFileName(File file) {
-        String fileName = file.getName();
         if (ignoreCase) {
-            fileName = fileName.toLowerCase();
+          line = line.toLowerCase();
         }
 
         for (String stopWord : stopWords) {
-            if (ignoreCase) {
-                stopWord = stopWord.toLowerCase();
-            }
-            if (fileName.contains(stopWord)) {
-                String entityType = file.isDirectory() ? "Directory" : "File";
-                handleStopWordDetected(
-                        String.format("%s name contains stop-word '%s', path: %s", entityType, stopWord, file.getPath())
-                );
-            }
+          if (ignoreCase) {
+            stopWord = stopWord.toLowerCase();
+          }
+          if (line.contains(stopWord)) {
+            handleStopWordDetected(
+                String.format(
+                    "File contains stop-word '%s', path: %s, line %s",
+                    stopWord, file.getPath(), lineNum));
+          }
         }
+      }
+
+      cache.addToCache(file);
+    } catch (FileNotFoundException e) {
+      getLog().error(String.format("File with path %s wasn't found", file.getPath()));
     }
+  }
 
-    /**
-     * Check file content for stop-words
-     *
-     * @param file to check
-     */
-    private void checkFileContent(File file) {
-        if (!cache.isFileChanged(file)) {
-            getLog().debug("file wasn't change " + file.getAbsolutePath());
-            return;
-        }
-
-        try {
-            Scanner scanner = new Scanner(file);
-
-            int lineNum = 0;
-            while (scanner.hasNextLine()) {
-                String line = scanner.nextLine();
-                lineNum++;
-
-                if (ignoreCase) {
-                    line = line.toLowerCase();
-                }
-
-                for (String stopWord : stopWords) {
-                    if (ignoreCase) {
-                        stopWord = stopWord.toLowerCase();
-                    }
-                    if (line.contains(stopWord)) {
-                        handleStopWordDetected(
-                                String.format("File contains stop-word '%s', path: %s, line %s", stopWord, file.getPath(), lineNum)
-                        );
-                    }
-                }
-            }
-
-            cache.addToCache(file);
-        } catch (FileNotFoundException e) {
-            getLog().error(String.format("File with path %s wasn't found", file.getPath()));
-        }
+  /**
+   * Checks is file should be excluded for checking.
+   *
+   * @param file to check
+   * @return boolean result
+   */
+  private boolean isFileExcluded(File file) {
+    try {
+      String canonicalFilePath = file.getCanonicalPath();
+      return excludeCanonical.contains(canonicalFilePath);
+    } catch (IOException e) {
+      e.printStackTrace();
+      return false;
     }
+  }
 
-    /**
-     * Checks is file should be excluded for checking
-     *
-     * @param file to check
-     * @return boolean result
-     */
-    private boolean isFileExcluded(File file) {
-        try {
-            String canonicalFilePath = file.getCanonicalPath();
-            return excludeCanonical.contains(canonicalFilePath);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return false;
-        }
+  /**
+   * Handle stop word detecting.
+   *
+   * @param errorMsg - error message to work with
+   */
+  private void handleStopWordDetected(String errorMsg) {
+    if (errorLevel.equals("WARN")) {
+      getLog().warn(errorMsg);
+    } else if (errorLevel.equals("ERROR")) {
+      getLog().error(errorMsg);
+      hasErrors = true;
     }
+  }
 
-    /**
-     * Handle stop word detecting
-     *
-     * @param errorMsg - error message to work with
-     */
-    private void handleStopWordDetected(String errorMsg) {
-        if (errorLevel.equals("WARN")) {
-            getLog().warn(errorMsg);
-        } else if (errorLevel.equals("ERROR")) {
-            getLog().error(errorMsg);
-            hasErrors = true;
-        }
-    }
-
-    /**
-     * Handle no-access file situation
-     *
-     * @param file with no-access
-     */
-    private void handleNoAccess(File file) {
-        getLog().warn("No access to read " + file.getAbsolutePath());
-    }
+  /**
+   * Handle no-access file situation.
+   *
+   * @param file with no-access
+   */
+  private void handleNoAccess(File file) {
+    getLog().warn("No access to read " + file.getAbsolutePath());
+  }
 }

--- a/src/main/java/sample/plugin/StopListMojo.java
+++ b/src/main/java/sample/plugin/StopListMojo.java
@@ -1,0 +1,258 @@
+package sample.plugin;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+/**
+ * Plugin for search and react on stop-words in project
+ */
+@Mojo(name = "check", defaultPhase = LifecyclePhase.COMPILE)
+public class StopListMojo extends AbstractMojo {
+
+    /**
+     * List of files/folders where search will be excluded
+     */
+    @Parameter(property = "excludes")
+    private List<String> excludes = new ArrayList<>();
+
+    /**
+     * List of cached canonical paths of excludes param
+     */
+    private List<String> excludeCanonical = new ArrayList<>();
+
+    /**
+     * List of stop-words to search for
+     */
+    @Parameter(property = "stopWords", required = true)
+    private List<String> stopWords = new ArrayList<>();
+
+    /**
+     * Error level of plugin.
+     * Acceptable values is "WARN" and "ERROR"
+     * <p>
+     * On "WARN" plugin is just log if stop-words was found
+     * On "ERROR" plugin is breaking the build
+     */
+    @Parameter(defaultValue = "WARN", property = "errorLevel")
+    String errorLevel;
+
+    /**
+     * Should or not case of stop words will be ignored
+     */
+    @Parameter(defaultValue = "false")
+    private boolean ignoreCase;
+
+    /**
+     * If errors was found build will be breaking
+     */
+    private boolean hasErrors = false;
+
+    @Inject
+    private StopListCache cache;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        init();
+        checkInDirectory(new File("."));
+
+        beforeClose();
+        if (hasErrors) {
+            throw new MojoExecutionException("Stop-words found in source!");
+        }
+    }
+
+    /**
+     * Runs in start of plugin work
+     */
+    private void init() {
+        initCanonicalPaths();
+        cache.setLogger(getLog());
+        cache.beforeStart();
+    }
+
+    /**
+     * Runs before plugin finish work
+     */
+    private void beforeClose() {
+        cache.beforeClose();
+    }
+
+    /**
+     * Fill exclude canonical paths
+     */
+    private void initCanonicalPaths() {
+        for (String excludePath : excludes) {
+            File file = new File(excludePath);
+            if (!file.exists()) {
+                continue;
+            }
+
+            try {
+                excludeCanonical.add(file.getCanonicalPath());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Recursive search in directory and files
+     *
+     * @param directory where search to start
+     */
+    private void checkInDirectory(File directory) {
+        if (!directory.canRead()) {
+            handleNoAccess(directory);
+            return;
+        }
+
+        File[] files = directory.listFiles();
+        if (files == null) {
+            return;
+        }
+
+        for (File file : files) {
+            if (isFileExcluded(file)) {
+                continue;
+            }
+
+            checkFile(file);
+            if (file.isDirectory()) {
+                checkInDirectory(file);
+            }
+        }
+    }
+
+    /**
+     * Checks file for stop-words
+     *
+     * @param file to check
+     */
+    private void checkFile(File file) {
+        if (!file.canRead()) {
+            handleNoAccess(file);
+            return;
+        }
+
+        checkFileName(file);
+        if (!file.isDirectory()) {
+            checkFileContent(file);
+        }
+    }
+
+    /**
+     * Check file name for stop-words
+     *
+     * @param file to check
+     */
+    private void checkFileName(File file) {
+        String fileName = file.getName();
+        if (ignoreCase) {
+            fileName = fileName.toLowerCase();
+        }
+
+        for (String stopWord : stopWords) {
+            if (ignoreCase) {
+                stopWord = stopWord.toLowerCase();
+            }
+            if (fileName.contains(stopWord)) {
+                String entityType = file.isDirectory() ? "Directory" : "File";
+                handleStopWordDetected(
+                        String.format("%s name contains stop-word '%s', path: %s", entityType, stopWord, file.getPath())
+                );
+            }
+        }
+    }
+
+    /**
+     * Check file content for stop-words
+     *
+     * @param file to check
+     */
+    private void checkFileContent(File file) {
+        if (!cache.isFileChanged(file)) {
+            getLog().debug("file wasn't change " + file.getAbsolutePath());
+            return;
+        }
+
+        try {
+            Scanner scanner = new Scanner(file);
+
+            int lineNum = 0;
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+                lineNum++;
+
+                if (ignoreCase) {
+                    line = line.toLowerCase();
+                }
+
+                for (String stopWord : stopWords) {
+                    if (ignoreCase) {
+                        stopWord = stopWord.toLowerCase();
+                    }
+                    if (line.contains(stopWord)) {
+                        handleStopWordDetected(
+                                String.format("File contains stop-word '%s', path: %s, line %s", stopWord, file.getPath(), lineNum)
+                        );
+                    }
+                }
+            }
+
+            cache.addToCache(file);
+        } catch (FileNotFoundException e) {
+            getLog().error(String.format("File with path %s wasn't found", file.getPath()));
+        }
+    }
+
+    /**
+     * Checks is file should be excluded for checking
+     *
+     * @param file to check
+     * @return boolean result
+     */
+    private boolean isFileExcluded(File file) {
+        try {
+            String canonicalFilePath = file.getCanonicalPath();
+            return excludeCanonical.contains(canonicalFilePath);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Handle stop word detecting
+     *
+     * @param errorMsg - error message to work with
+     */
+    private void handleStopWordDetected(String errorMsg) {
+        if (errorLevel.equals("WARN")) {
+            getLog().warn(errorMsg);
+        } else if (errorLevel.equals("ERROR")) {
+            getLog().error(errorMsg);
+            hasErrors = true;
+        }
+    }
+
+    /**
+     * Handle no-access file situation
+     *
+     * @param file with no-access
+     */
+    private void handleNoAccess(File file) {
+        getLog().warn("No access to read " + file.getAbsolutePath());
+    }
+}

--- a/src/main/java/sample/plugin/StopListMojo.java
+++ b/src/main/java/sample/plugin/StopListMojo.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Scanner;
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 
@@ -147,22 +148,10 @@ public class StopListMojo extends AbstractMojo {
    * @param file to check
    */
   private void checkFileName(File file) {
-    String fileName = file.getName();
-    if (ignoreCase) {
-      fileName = fileName.toLowerCase();
-    }
-
-    for (String stopWord : stopWords) {
-      if (ignoreCase) {
-        stopWord = stopWord.toLowerCase();
-      }
-      if (fileName.contains(stopWord)) {
-        String entityType = file.isDirectory() ? "Directory" : "File";
-        handleStopWordDetected(
-            String.format(
-                "%s name contains stop-word '%s', path: %s", entityType, stopWord, file.getPath()));
-      }
-    }
+    String entityType = file.isDirectory() ? "Directory" : "File";
+    String errorMessage =
+        String.format("%s name contains stop-word, path: %s", entityType, file.getPath());
+    checkStringForStopWords(file.getName(), errorMessage);
   }
 
   /**
@@ -221,15 +210,20 @@ public class StopListMojo extends AbstractMojo {
    * @param errorMessage - error message for log
    */
   private void checkStringForStopWords(String content, String errorMessage) {
-    for (String stopWord : stopWords) {
-      if (ignoreCase) {
-        stopWord = stopWord.toLowerCase();
-      }
+    stopWords.forEach(
+        stopWord -> {
+          boolean containsStopWord;
 
-      if (content.contains(stopWord)) {
-        handleStopWordDetected(errorMessage + ", stop word: " + stopWord);
-      }
-    }
+          if (ignoreCase) {
+            containsStopWord = StringUtils.containsIgnoreCase(content, stopWord);
+          } else {
+            containsStopWord = content.contains(stopWord);
+          }
+
+          if (containsStopWord) {
+            handleStopWordDetected(errorMessage + ", stop word: " + stopWord);
+          }
+        });
   }
 
   /**

--- a/src/test/java/sample/plugin/StopListMojoTest.java
+++ b/src/test/java/sample/plugin/StopListMojoTest.java
@@ -13,7 +13,7 @@ public class StopListMojoTest {
 
   @Test
   public void testPluginRun() throws Exception {
-    File pom = new File("target/test-classes/project-to-test/");
+    File pom = new File("src/test/resources/project-to-test/");
     assertNotNull(pom);
     assertTrue(pom.exists());
     StopListMojo myMojo = (StopListMojo) rule.lookupConfiguredMojo(pom, "check");

--- a/src/test/java/sample/plugin/StopListMojoTest.java
+++ b/src/test/java/sample/plugin/StopListMojoTest.java
@@ -1,28 +1,22 @@
 package sample.plugin;
 
-
-import org.apache.maven.plugin.testing.MojoRule;
-
-import org.junit.Rule;
-
-import static org.junit.Assert.*;
-
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class StopListMojoTest {
-    @Rule
-    public MojoRule rule = new MojoRule() {};
+  @Rule public MojoRule rule = new MojoRule() {};
 
-    @Test
-    public void testPluginRun() throws Exception {
-        File pom = new File("target/test-classes/project-to-test/");
-        assertNotNull(pom);
-        assertTrue(pom.exists());
-        StopListMojo myMojo = (StopListMojo) rule.lookupConfiguredMojo(pom, "check");
-        myMojo.execute();
-    }
-
+  @Test
+  public void testPluginRun() throws Exception {
+    File pom = new File("target/test-classes/project-to-test/");
+    assertNotNull(pom);
+    assertTrue(pom.exists());
+    StopListMojo myMojo = (StopListMojo) rule.lookupConfiguredMojo(pom, "check");
+    myMojo.execute();
+  }
 }
-

--- a/src/test/java/sample/plugin/StopListMojoTest.java
+++ b/src/test/java/sample/plugin/StopListMojoTest.java
@@ -1,0 +1,28 @@
+package sample.plugin;
+
+
+import org.apache.maven.plugin.testing.MojoRule;
+
+import org.junit.Rule;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import java.io.File;
+
+public class StopListMojoTest {
+    @Rule
+    public MojoRule rule = new MojoRule() {};
+
+    @Test
+    public void testPluginRun() throws Exception {
+        File pom = new File("target/test-classes/project-to-test/");
+        assertNotNull(pom);
+        assertTrue(pom.exists());
+        StopListMojo myMojo = (StopListMojo) rule.lookupConfiguredMojo(pom, "check");
+        myMojo.execute();
+    }
+
+}
+

--- a/src/test/java/sample/plugin/StopListMojoTest.java
+++ b/src/test/java/sample/plugin/StopListMojoTest.java
@@ -13,7 +13,7 @@ public class StopListMojoTest {
 
   @Test
   public void testPluginRun() throws Exception {
-    File pom = new File("src/test/resources/project-to-test/");
+    File pom = new File(getClass().getResource("/project-to-test").getFile());
     assertNotNull(pom);
     assertTrue(pom.exists());
     StopListMojo myMojo = (StopListMojo) rule.lookupConfiguredMojo(pom, "check");

--- a/src/test/resources/FileWithContent.txt
+++ b/src/test/resources/FileWithContent.txt
@@ -1,0 +1,1 @@
+This file contains word "Bill"

--- a/src/test/resources/project-to-test/pom.xml
+++ b/src/test/resources/project-to-test/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>sample.plugin</groupId>
+    <artifactId>stoplist-maven-plugin</artifactId>
+    <version>1.2-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>stoplist-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>Eclude1</exclude>
+                        <exclude>Eclude2</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Плагин для поиска стоп-слов в коде проекта (актуально в связи с последними новостями в Linux-сообществе).

### Конфигурация
**stopWords**
Список из стоп-слов, которые будут искаться в коде

**excludes**
Список папок/файлов, которые будут исключены из поиска

**errorLevel**
Принимает значение "WARN" и "ERROR". В случае "WARN" просто пишет предупреждения в консоль, в случае "ERROR" если были найдены стоп-слова, то прекращает сборку

**ignoreCase**
Нужно ли игнорировать кейс

### Кэширование
В плагине реализовано кэширование, которое позволяет не просматривать файлы, которые не были изменены с прошлого запуска плагина.

### Пример использования
**В pom.xml**
```
<plugin>
    <groupId>sample.plugin</groupId>
    <artifactId>stoplist-maven-plugin</artifactId>
    <version>1.0.1</version>
    <configuration>
        <errorLevel>WARN</errorLevel>
        <ignoreCase>true</ignoreCase>

        <excludes>
            <exclude>.idea</exclude>
            <exclude>./target</exclude>
            <exclude>./pom.xml</exclude>
        </excludes>

        <stopWords>
            <stopWord>javaScript</stopWord>
        </stopWords>
    </configuration>
    <executions>
        <execution>
            <id>on-compile</id>
            <phase>compile</phase>
            <goals>
                <goal>check</goal>
            </goals>
        </execution>
    </executions>
</plugin>
```

**Из консоли**
`$ mvn sample.plugin:stoplist-maven-plugin:check -DstopWords=javaScript,php -Dexcludes=pom.xml,.idea -DerrorLevel=ERROR`